### PR TITLE
Add support for setting sensor parameters externally

### DIFF
--- a/calib.sh
+++ b/calib.sh
@@ -24,10 +24,17 @@ imu_topic_name=(
 #"/imu3/data_sync"
 )
 
+# For data association.
 bag_start=1
 bag_durr=30
 scan4map=15
 timeOffsetPadding=0.015
+
+# For sensor modeling.
+gyroscope_noise=8.72665e-5
+accelerometer_noise=1.96133e-4
+lidar_noise=0.03
+imu_rate=250.0
 
 show_ui=true  #false
 
@@ -58,6 +65,10 @@ for i in "${!sync_bag_name[@]}"; do
                           lidar_model:="VLP_16" \
                           time_offset_padding:="${timeOffsetPadding}"\
                           ndtResolution:="${ndtResolution}" \
-                          show_ui:="${show_ui}"
+                          show_ui:="${show_ui}" \
+                          gyroscope_noise:="${gyroscope_noise}" \
+                          accelerometer_noise:="${accelerometer_noise}" \
+                          lidar_noise:="${lidar_noise}" \
+                          imu_rate:="${imu_rate}"
     done
 done

--- a/calib.sh
+++ b/calib.sh
@@ -31,10 +31,10 @@ scan4map=15
 timeOffsetPadding=0.015
 
 # For sensor modeling.
-gyroscope_noise=8.72665e-5
-accelerometer_noise=1.96133e-4
-lidar_noise=0.03
-imu_rate=250.0
+gyroscope_noise=0.001745
+accelerometer_noise=0.000588
+lidar_noise=0.02
+imu_rate=400.0
 
 show_ui=true  #false
 

--- a/include/core/calibration.hpp
+++ b/include/core/calibration.hpp
@@ -45,18 +45,6 @@ public:
           gyro_bias(Eigen::Vector3d(0,0,0)),
           acce_bias(Eigen::Vector3d(0,0,0)) {
 
-    double gyroscope_noise_density = 1.745e-4;
-    double accelerometer_noise_density = 5.88e-4;
-    double imu_rate = 400.0;
-    double lidar_noise = 0.02;
-
-    double gyro_discrete = gyroscope_noise_density * std::sqrt(imu_rate);
-    double acce_discrete = accelerometer_noise_density * std::sqrt(imu_rate);
-
-    global_opt_gyro_weight = 1.0 / std::pow(gyro_discrete, 2);  // 8.21e4
-    global_opt_acce_weight = 1.0 / std::pow(acce_discrete, 2);  // 7.23e3
-    global_opt_lidar_weight = 1.0 / std::pow(lidar_noise, 2);   // 2.5e3
-
     // fine-tuned parameter
     global_opt_gyro_weight = 28.0;
     global_opt_acce_weight = 18.5;
@@ -85,6 +73,29 @@ public:
 
   void set_acce_bias(Eigen::Vector3d ab) {
     acce_bias = ab;
+  }
+
+  void set_opt_weights(const double gyroscope_noise,
+                       const double accelerometer_noise,
+                       const double lidar_noise,
+                       const double imu_rate) {
+    double gyro_discrete = gyroscope_noise * std::sqrt(imu_rate);
+    double acce_discrete = accelerometer_noise * std::sqrt(imu_rate);
+
+    global_opt_gyro_weight = 1.0 / std::pow(gyro_discrete, 2);
+    global_opt_acce_weight = 1.0 / std::pow(acce_discrete, 2);
+    global_opt_lidar_weight = 1.0 / std::pow(lidar_noise, 2);
+  }
+
+  bool areSensorParamsDefault(const double gyroscope_noise,
+                              const double accelerometer_noise,
+                              const double lidar_noise,
+                              const double imu_rate,
+                              const double tol = 1e-6) {
+    return( (fabs(default_gyro_noise_density_ - gyroscope_noise) < tol) &&
+            (fabs(default_accel_noise_density_ - accelerometer_noise) < tol) &&
+            (fabs(default_lidar_noise_ - lidar_noise) < tol) &&
+            (fabs(default_imu_rate_ - imu_rate) < tol) );
   }
 
   void showStates() const {
@@ -133,6 +144,15 @@ public:
   Eigen::Vector3d gyro_bias;
 
   Eigen::Vector3d acce_bias;
+
+  ///default sensor parameters
+  double default_gyro_noise_density_ = 1.745e-4;
+
+  double default_accel_noise_density_ = 5.88e-4;
+
+  double default_lidar_noise_ = 0.02;
+
+  double default_imu_rate_ = 400.0;
 
   ///weight
   double global_opt_gyro_weight;

--- a/launch/licalib_gui.launch
+++ b/launch/licalib_gui.launch
@@ -7,9 +7,13 @@
     <arg name="scan4map"            default="15" />
     <arg name="lidar_model"         default="VLP_16" />
     <arg name="ndtResolution"       default="0.5" /> <!-- 0.5 for indoor case and 1.0 for outdoor case -->
-
     <arg name="time_offset_padding" default="0.015" />
     <arg name="show_ui"    default="false" />
+
+    <arg name="gyroscope_noise"     default="0.001745" />       <!-- for sensor modeling -->
+    <arg name="accelerometer_noise" default="0.000588" />
+    <arg name="lidar_noise"         default="0.02" />
+    <arg name="imu_rate"            default="400.0" />
 
     <node pkg="li_calib" type="li_calib_gui" name="li_calib_gui" output="screen">
     <!-- <node pkg="li_calib" type="li_calib_gui" name="li_calib_gui" output="screen" clear_params="true" launch-prefix="gdb -ex run &#45;&#45;args">-->
@@ -22,13 +26,13 @@
         <param name="bag_durr"            type="double"   value="$(arg bag_durr)" />  <!-- for data association -->
         <param name="scan4map"            type="double"   value="$(arg scan4map)" />
         <param name="ndtResolution"       type="double"   value="$(arg ndtResolution)" />
-        <param name="gyroscope_noise"     type="double"   value="1.745e-4" />       <!-- for sensor modeling -->
-        <param name="accelerometer_noise" type="double"   value="5.88e-4" />
-        <param name="lidar_noise"         type="double"   value="0.02" />
-        <param name="imu_rate"            type="double"   value="400.0" />
+        <param name="gyroscope_noise"     type="double"   value="$(arg gyroscope_noise)" />       <!-- for sensor modeling -->
+        <param name="accelerometer_noise" type="double"   value="$(arg accelerometer_noise)" />
+        <param name="lidar_noise"         type="double"   value="$(arg lidar_noise)" />
+        <param name="imu_rate"            type="double"   value="$(arg imu_rate)" />
 
-        <param name="time_offset_padding"   type="double"   value="$(arg time_offset_padding)" />
-        <param name="show_ui"               type="bool"     value="$(arg show_ui)" />
+        <param name="time_offset_padding" type="double"   value="$(arg time_offset_padding)" />
+        <param name="show_ui"             type="bool"     value="$(arg show_ui)" />
     </node>
 
 </launch>

--- a/launch/licalib_gui.launch
+++ b/launch/licalib_gui.launch
@@ -14,14 +14,18 @@
     <node pkg="li_calib" type="li_calib_gui" name="li_calib_gui" output="screen">
     <!-- <node pkg="li_calib" type="li_calib_gui" name="li_calib_gui" output="screen" clear_params="true" launch-prefix="gdb -ex run &#45;&#45;args">-->
 
-        <param name="topic_imu"         type="string"   value="$(arg topic_imu)" />
-        <param name="topic_lidar"       type="string"   value="/velodyne_packets" />
-        <param name="LidarModel"        type="string"   value="$(arg lidar_model)" />
-        <param name="path_bag"          type="string"   value="$(arg path_bag)" />
-        <param name="bag_start"         type="double"   value="$(arg bag_start)" />
-        <param name="bag_durr"          type="double"   value="$(arg bag_durr)" /> <!-- for data association -->
-        <param name="scan4map"          type="double"   value="$(arg scan4map)" />
-        <param name="ndtResolution"     type="double"   value="$(arg ndtResolution)" />
+        <param name="topic_imu"           type="string"   value="$(arg topic_imu)" />
+        <param name="topic_lidar"         type="string"   value="/velodyne_packets" />
+        <param name="LidarModel"          type="string"   value="$(arg lidar_model)" />
+        <param name="path_bag"            type="string"   value="$(arg path_bag)" />
+        <param name="bag_start"           type="double"   value="$(arg bag_start)" />
+        <param name="bag_durr"            type="double"   value="$(arg bag_durr)" />  <!-- for data association -->
+        <param name="scan4map"            type="double"   value="$(arg scan4map)" />
+        <param name="ndtResolution"       type="double"   value="$(arg ndtResolution)" />
+        <param name="gyroscope_noise"     type="double"   value="1.745e-4" />       <!-- for sensor modeling -->
+        <param name="accelerometer_noise" type="double"   value="5.88e-4" />
+        <param name="lidar_noise"         type="double"   value="0.02" />
+        <param name="imu_rate"            type="double"   value="400.0" />
 
         <param name="time_offset_padding"   type="double"   value="$(arg time_offset_padding)" />
         <param name="show_ui"               type="bool"     value="$(arg show_ui)" />


### PR DESCRIPTION
First of all, congratulations on your paper publication! Targetless calibration for LiDAR-IMU systems is very interesting for a number of applications. I have been working on a LiDAR-IMU calibration pipeline myself, and as you mention in your paper, there is a lack of open-sourced packages for this problem. I would personally like to thank you for your contribution to the community.
I have been using your tool to get a reliable calibration, and plan to use it to benchmark my own algorithm. 

I would like to contribute to your project by allowing the user to externally set the gyroscope/accelerometer noise densities, LiDAR noise and IMU rate, so that the optimization weights may be computed according to the user's specific sensors. 

The proposed changes in this pull request include:
- Allow providing said parameters via the main calibration script "calib.sh" and the launch file "launch/licalib_gui.launch".
- Implement default values in "calibration.hpp", and a way to check and update the optimization weights in "src/ui/calib_helper.cpp".

Tested in Ubuntu 18.04